### PR TITLE
Update queries with readMode

### DIFF
--- a/posts/2021-02-17-multiregion-serverless-apps.md
+++ b/posts/2021-02-17-multiregion-serverless-apps.md
@@ -180,7 +180,7 @@ Recall that when we created our Uni, we seeded it with data from the `initial-st
 
 ```graphql
 query listTemperatures {
- listTemperatures {
+ listTemperatures(readMode: NODE_COMMITTED) {
    Temperatures {
      timestamp
      airportCode
@@ -194,7 +194,7 @@ Next, let's go back to our uni's setting page and click on the 'Open GraphQL Exp
 
 ```graphql
 query listTemperatures {
- list_TemperatureItems {
+ list_TemperatureItems(readMode: NODE_COMMITTED) {
    _TemperatureItems {
      timestamp
      airportCode
@@ -239,7 +239,7 @@ At this point we've added a new temperature.  Let's make sure it's visible acros
 
 ```graphql
 query listTemperatures {
- list_TemperatureItems {
+ list_TemperatureItems(readMode: NODE_COMMITTED) {
    _TemperatureItems {
      timestamp
      airportCode
@@ -255,7 +255,7 @@ Let's go back to the uni setting page and click on the 'Open GraphQL Explorer' o
 
 ```graphql
 query listTemperatures {
- listTemperatures {
+ listTemperatures(readMode: NODE_COMMITTED) {
    Temperatures {
      timestamp
      airportCode

--- a/posts/2021-02-18-sharing-files-in-a-uni.md
+++ b/posts/2021-02-18-sharing-files-in-a-uni.md
@@ -101,7 +101,7 @@ After your **__AddFile__** mutation executes, the new file will be visible to al
 
 ```graphql
 query ListAllFiles {
-  listVendia_FileItems {
+  listVendia_FileItems(readMode: NODE_COMMITTED) {
     Vendia_FileItems {
       _id
       destinationKey
@@ -124,7 +124,7 @@ You can bring up a GraphQL explorer for the other node in your Uni and you will 
 
 ```graphql
 query ListAllFiles {
-  listVendia_FileItems {
+  listVendia_FileItems(readMode: NODE_COMMITTED) {
     Vendia_FileItems {
       _id
       destinationKey

--- a/posts/2021-09-01-sharing-data-with-fine-grained-control.md
+++ b/posts/2021-09-01-sharing-data-with-fine-grained-control.md
@@ -271,7 +271,7 @@ Run this query from either the `Bob` or `Eve` GraphQL Explorer.
 
 ```graphql
 query listRecipes {
-  list_RecipeItems {
+  list_RecipeItems(readMode: NODE_COMMITTED) {
     _RecipeItems {
       ... on Self_Recipe {
         _id
@@ -435,7 +435,7 @@ First, we will need to identify the **_id** of the Red Velvet Cake recipe.
 
 ```graphql
 query listRecipes {
-  list_RecipeItems(filter: {name: {eq: "Red Velvet Cake"}}) {
+  list_RecipeItems(filter: {name: {eq: "Red Velvet Cake"}}, readMode: NODE_COMMITTED) {
     _RecipeItems {
       ... on Self_Recipe {
         _id
@@ -565,7 +565,7 @@ Now that `Eve` has purchased the Red Velvet Cake recipe and Alice has updated pe
 
 ```graphql
 query listRecipes {
-  list_RecipeItems {
+  list_RecipeItems(readMode: NODE_COMMITTED) {
     _RecipeItems {
       ... on Self_Recipe {
         _id

--- a/posts/2022-01-04-azure-eventing.md
+++ b/posts/2022-01-04-azure-eventing.md
@@ -413,7 +413,7 @@ To finalize this integration, we next:
     
       ```graphql
       query getAzureSettings {
-        getVendia_Settings {
+        getVendia_Settings(readMode: NODE_COMMITTED) {
           azure {
             blockReportFunctions {
               functionName
@@ -440,7 +440,7 @@ Now it's time for the Supplier (from its Vendia Share AWS Node) to make a Purcha
     
       ```graphql
       query listPurchaseOrders {
-        list_PurchaseOrderItems {
+        list_PurchaseOrderItems(readMode: NODE_COMMITTED) {
           _PurchaseOrderItems {
             _id
             _owner

--- a/posts/2022-03-09-graphql-and-blockchain.md
+++ b/posts/2022-03-09-graphql-and-blockchain.md
@@ -69,7 +69,7 @@ When used to query data, Vendia Transactions ensure that all nodes will see the 
 
 ```graphql
 query q @vendia_transaction {
-  get_Inventory(id: "017d92a7-0ab5-5513-fac1-c50be330f057") {
+  get_Inventory(id: "017d92a7-0ab5-5513-fac1-c50be330f057", readMode: NODE_COMMITTED) {
     _id
     itemName
     itemNumber
@@ -113,7 +113,7 @@ Vendia Share captures all changes to data in a Uni in a ledger. This is somethin
 
 ```graphql
 query blocksQuery {
-  listVendia_BlockItems {
+  listVendia_BlockItems(readMode: NODE_COMMITTED) {
     Vendia_BlockItems {
       blockId
       blockHash

--- a/posts/2022-05-25-smart-contract-feature-example.md
+++ b/posts/2022-05-25-smart-contract-feature-example.md
@@ -66,7 +66,7 @@ The `inputQuery` retrieves information from the Uni and provides it as input dur
 
 ```graphql
 query ValidationInputQuery($loanIdentifier: String!) {
-  list_LoanItems(filter: {loanIdentifier: {eq: $loanIdentifier}}) {
+  list_LoanItems(filter: {loanIdentifier: {eq: $loanIdentifier}}, readMode: NODE_COMMITTED) {
     _LoanItems {
       ... on Self_Loan {
         _id

--- a/posts/typography.mdx
+++ b/posts/typography.mdx
@@ -187,7 +187,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer vitae mauris ar
     
       ```graphql
       query listPurchaseOrders {
-        list_PurchaseOrderItems {
+        list_PurchaseOrderItems(readMode: NODE_COMMITTED) {
           _PurchaseOrderItems {
             _id
             _owner


### PR DESCRIPTION
Updating blog example queries to use the new WAL `readMode`. I set all the examples to use `NODE_COMMITTED` which is the default if a user doesn't select any `readMode`.