### PR TITLE
remove syncMode from mutation examples

### DIFF
--- a/posts/2021-02-17-multiregion-serverless-apps.md
+++ b/posts/2021-02-17-multiregion-serverless-apps.md
@@ -222,7 +222,6 @@ mutation addTemp {
      timestamp: "2021-01-01T03:00:00Z",
      temperature: 1.5
    }
-   syncMode: ASYNC
    ){
      transaction {
       transactionId

--- a/posts/2021-02-18-sharing-files-in-a-uni.md
+++ b/posts/2021-02-18-sharing-files-in-a-uni.md
@@ -79,7 +79,6 @@ mutation AddFile {
       sourceRegion: "<REGION OF YOUR S3 BUCKET>",
       destinationKey: "my-first-file.txt"
     }
-    syncMode: ASYNC
   ) {
   transaction {
       transactionId
@@ -158,7 +157,6 @@ mutation UpdateFile {
       sourceRegion: "",
       destinationKey: ""
     }
-    syncMode: ASYNC
   ) {
   transaction {
       transactionId
@@ -192,7 +190,6 @@ mutation AddFile2 {
       destinationKey: "my-second-file.txt",
       read: ["TestNode1"]
     }
-    syncMode: ASYNC
   ){
   transaction {
       transactionId
@@ -234,7 +231,6 @@ mutation AddFile3 {
       destinationKey: "my-third-file.txt",
       write: ["*"]
     }
-    syncMode: ASYNC
   ){
   transaction {
       transactionId

--- a/posts/2021-09-01-sharing-data-with-fine-grained-control.md
+++ b/posts/2021-09-01-sharing-data-with-fine-grained-control.md
@@ -242,7 +242,6 @@ mutation addSprinklesCupcake {
         }
       ]
     }
-    syncMode: ASYNC
   ) {
     transaction {
       transactionId
@@ -410,7 +409,6 @@ mutation addRedVelvetCake {
             }
         ]
     }
-    syncMode: ASYNC
   ) {
       transaction {
           transactionId
@@ -543,7 +541,6 @@ mutation updateRedVelvetCakeAcl {
               },
           ]
       }
-      syncMode: ASYNC
     ) {
     transaction {
           transactionId

--- a/posts/2022-01-04-azure-eventing.md
+++ b/posts/2022-01-04-azure-eventing.md
@@ -387,7 +387,6 @@ To finalize this integration, we next:
               ]
             }
           }
-          syncMode: ASYNC
         ) {
           transaction {
             transactionId
@@ -471,7 +470,6 @@ Now it's time for the Supplier (from its Vendia Share AWS Node) to make a Purcha
           input: {
             expected: "2022-01-03T00:00:00Z"
           }
-          syncMode: ASYNC
         ) {
           transaction {
             transactionId

--- a/posts/2022-03-09-graphql-and-blockchain.md
+++ b/posts/2022-03-09-graphql-and-blockchain.md
@@ -21,12 +21,12 @@ In cases where ordering isn't important, or when you don't need to guarantee bot
 
 ```graphql
 mutation m {
-  warehouse1: update_Inventory(id: "017d92a7-0ab5-5513-fac1-c50be330f057", input: {quantityWarehouse1: 90, lastUpdated: "2021-12-06T18:30:00Z"} syncMode: ASYNC) {
+  warehouse1: update_Inventory(id: "017d92a7-0ab5-5513-fac1-c50be330f057", input: {quantityWarehouse1: 90, lastUpdated: "2021-12-06T18:30:00Z"}) {
     transaction {
       transactionId
     }
   }
-  warehouse2: update_Inventory(id: "017d92a7-0ab5-5513-fac1-c50be330f057", input: {quantityWarehouse2: 10, lastUpdated: "2021-12-06T18:30:00Z"} syncMode: ASYNC) {
+  warehouse2: update_Inventory(id: "017d92a7-0ab5-5513-fac1-c50be330f057", input: {quantityWarehouse2: 10, lastUpdated: "2021-12-06T18:30:00Z"}) {
    transaction {
       transactionId
     }
@@ -48,12 +48,12 @@ When used with a mutation to create, change, or delete data, Vendia Transactions
 
 ```graphql
 mutation m @vendia_transaction {
-  warehouse1: update_Inventory(id: "017d92a7-0ab5-5513-fac1-c50be330f057", input: {quantityWarehouse1: 90, lastUpdated: "2021-12-06T18:30:00Z"} syncMode: ASYNC) {
+  warehouse1: update_Inventory(id: "017d92a7-0ab5-5513-fac1-c50be330f057", input: {quantityWarehouse1: 90, lastUpdated: "2021-12-06T18:30:00Z"}) {
     transaction {
       transactionId
     }
   }
-  warehouse2: update_Inventory(id: "017d92a7-0ab5-5513-fac1-c50be330f057", input: {quantityWarehouse2: 10, lastUpdated: "2021-12-06T18:30:00Z"} syncMode: ASYNC) {
+  warehouse2: update_Inventory(id: "017d92a7-0ab5-5513-fac1-c50be330f057", input: {quantityWarehouse2: 10, lastUpdated: "2021-12-06T18:30:00Z"}) {
     transaction {
       transactionId
     }
@@ -93,7 +93,7 @@ Let's work through an example where we want to update the shipment date and item
 
 ```graphql
 mutation m {
-  update_PurchaseOrder(id: "017d92a7-0ab5-5513-fac1-c50be330f092", input: {shipmentDate: "2021-02-16T09:00:00Z", quantity: 10}, condition: {warehouseQuantity: {gte: 100}} syncMode: ASYNC) {
+  update_PurchaseOrder(id: "017d92a7-0ab5-5513-fac1-c50be330f092", input: {shipmentDate: "2021-02-16T09:00:00Z", quantity: 10}, condition: {warehouseQuantity: {gte: 100}}) {
     transaction {
       transactionId
     }

--- a/posts/typography.mdx
+++ b/posts/typography.mdx
@@ -218,7 +218,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer vitae mauris ar
           input: {
             expected: "2022-01-03T00:00:00Z"
           }
-          syncMode: ASYNC) {
+        ) {
           transaction {
             submissionTime
             transactionId
@@ -244,7 +244,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer vitae mauris ar
           input: {
             expected: "2022-01-03T00:00:00Z"
           }
-          syncMode: ASYNC) {
+        ) {
           transaction {
             submissionTime
             transactionId
@@ -267,7 +267,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer vitae mauris ar
           input: {
             expected: "2022-01-03T00:00:00Z"
           }
-          syncMode: ASYNC) {
+        ) {
           transaction {
             submissionTime
             transactionId


### PR DESCRIPTION
Remove syncMode from mutations. With the new WAL feature, we changed the default from `NODE_LEDGERED` to `NODE_COMMITTED` which is a "faster" consistency mode. We consider `syncMode` to be an advanced feature that most customers will not use. Therefore, we will remove this from the mutations to simplify the examples in the blogs. 