### PR TITLE
fix: broken image link on posts/2022-03-24-adding-data-via-sftp.md

### DIFF
--- a/posts/2022-03-24-adding-data-via-sftp.md
+++ b/posts/2022-03-24-adding-data-via-sftp.md
@@ -23,6 +23,7 @@ Similarly, financial companies have their own risk-mitigation and security measu
 Sr. Solutions Architect, Brian McNamara, provides a [step-by-step guide](https://github.com/vendia/examples/tree/main/integrations/files/sftp-to-share) for adding files via SFTP to Vendia Share.
 
 The guides uses the [Vendia Share Command Line Interface (CLI)](https://vendia.net/docs/share/cli) and the [AWS Serverless Application Model (SAM)](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/what-is-sam.html). Serverless resources like a [AWS Transfer for SFTP](https://aws.amazon.com/aws-transfer-family/) endpoint, [AWS S3](https://aws.amazon.com/s3/) bucket and [AWS Lambda](https://aws.amazon.com/lambda/) function will be deployed. CSV processing with a AWS Lambda function will be triggered by transferring a file to the SFTP endpoint. The Lambda function parses CSVs and publishes data to a node's GraphQL endpoint.
-![https://github.com/vendia/examples/blob/main/share/sftp-to-share/img/sftp-to-share.png?raw=true](https://github.com/vendia/examples/tree/main/integrations/files/sftp-to-share/img/sftp-to-share.png?raw=true)
+
+![Diagram of SFTP to Vendia Share Integration](https://user-images.githubusercontent.com/113389580/192360015-4de95582-d3fb-46db-9679-f5b0c6091880.png)
 
 Go ahead and try to add a file to your Uni via SFTP and if you face any issues head over to our [Discourse Channel](https://community.vendia.net) to get some help... or better yet, share your success!


### PR DESCRIPTION
Modified image url to use image link from CDN for posts/2022-03-24-adding-data-via-sftp.md

You can see broken image link here: https://www.vendia.net/blog/adding-data-via-sftp

Preview of fix: https://staging-preview-fix-correct-image-path--vendia-site.netlify.app/blog/adding-data-via-sftp

Asana Task: [Fix image reference on SFTP blog](https://app.asana.com/0/1201537251366171/1202942793346789/f)