### PR TITLE
Update pancake intro field (string to wysiwyg)

### DIFF
--- a/pages/careers.md
+++ b/pages/careers.md
@@ -32,7 +32,8 @@ components:
     theme: White
     intro:
       title: Why Vendia?
-      text: Enjoy all the energy of startup life without exhaustion or drama.
+      text: >-
+        ### Enjoy all the energy of startup life without exhaustion or drama.
     columns:
       - text: >-
           ![](https://res.cloudinary.com/vendia/image/upload/c_fill,w_2000/v1669319829/Group_48095931_mgwd2a.svg)

--- a/pages/homepage.md
+++ b/pages/homepage.md
@@ -28,9 +28,9 @@ components:
     theme: white
     intro:
       title: Designed for sensitive data in regulated industries
-      text: Vendia Share is the only trusted data cloud that combines business
+      text: >-
+        ### Vendia Share is the only trusted data cloud that combines business
         blockchain, smart APIs, and cloud databases.
-    columns:
       - text: >-
           <img
           src="https://res.cloudinary.com/vendia/image/upload/v1675716790/Website/Icons/Frame_48095797_jcfwxu.png"  class="image-float-left"
@@ -183,8 +183,9 @@ components:
     theme: white
     intro:
       title: Resources
-      text: "Learn how business blockchains, smart APis, and cloud databases unlock
-        the next generation of data sharing. "
+      text: >-
+        ### Learn how business blockchains, smart APis, and cloud databases unlock
+        the next generation of data sharing. 
     columns:
       - text: >-
           ##### Blockchains and centralized IT

--- a/pages/industry-financial-services.md
+++ b/pages/industry-financial-services.md
@@ -54,7 +54,8 @@ components:
           Less time spent investigating and resolving data inconsistencies with Vendia Share
         wrapTheColumnInACard: false
     intro:
-      text: Take manual interventions out of the mix. Instead, instantly, accurately
+      text: >-
+        ### Take manual interventions out of the mix. Instead, instantly, accurately
         reconcile data from inside and outside your four walls — no matter how
         many (or messy) your partner systems, clouds, companies, or inputs.
       title: Operate with a golden record everyone can trust
@@ -160,7 +161,8 @@ components:
         wrapTheColumnInACard: false
     intro:
       title: Why financial services leaders trust Vendia Share
-      text: Achieve winning business results across use cases with our SaaS platform
+      text: >-
+        ### Achieve winning business results across use cases with our SaaS platform
         for real-time, multi-partner B2B data sharing.
     maxColumns: "4"
   - type: MediaWithTextTwoColumns

--- a/pages/industry-supply-chain-visibility.md
+++ b/pages/industry-supply-chain-visibility.md
@@ -72,13 +72,15 @@ components:
           On average, Vendia Share customers spend **87% less time investigating** and resolving data inconsistencies.
         wrapTheColumnInACard: false
     intro:
-      text: Optimize for cost-efficiency without sacrificing resiliency
       title: "Stop the swings from surpluses to shortages "
+      text: >-
+        ### Optimize for cost-efficiency without sacrificing resiliency
   - type: Columns
     theme: light
     intro:
       title: What does Vendia Share solve for?
-      text: Share and access sub-tier partner data with trust, ease, security, and
+      text: >-
+        ### Share and access sub-tier partner data with trust, ease, security, and
         built-in compliance
     columns:
       - text: >-
@@ -174,7 +176,8 @@ components:
     maxColumns: "2"
     intro:
       title: What kinds of results can you expect?
-      text: What would you do with more data, more time, and more money?
+      text: >-
+        ### What would you do with more data, more time, and more money?
   - type: MediaWithText
     mediaPosition: right
     text: >-

--- a/pages/product-diy-vs-vendia.md
+++ b/pages/product-diy-vs-vendia.md
@@ -37,7 +37,8 @@ components:
         of all three.
     intro:
       title: APIs, blockchains, and databases together at last.
-      text: Vendia Share combines the best functions, features, and benefits of these
+      text: >-
+        ### Vendia Share combines the best functions, features, and benefits of these
         proven technologies and IT workhorses.
   - type: Columns
     theme: white
@@ -78,7 +79,8 @@ components:
         wrapTheColumnInACard: false
     intro:
       title: Secure sharing as a service
-      text: Avoid the complexity of building multi-cloud, custom AuthN and AuthZ
+      text: >-
+        ### Avoid the complexity of building multi-cloud, custom AuthN and AuthZ
         services with Vendia Share.
   - type: MediaWithTextTwoColumns
     mediaPosition: right
@@ -171,7 +173,7 @@ components:
       The Vendia Share platform eliminates the need for DIY API creation and the underlying infrastructure design, provisioning, and management.
 
 
-      All you need is a JSON schema. Vendia Share does the rest.   
+      All you need is a JSON schema. Vendia Share does the rest. 
 
 
       Vendia Share compiles that schema into Serverless resources customized to your model and then deploys a powerful, fully-managed https-based GraphQL engine for reading and writing your data, with full type checking.

--- a/pages/product-how-to-get-started-with-vendia.md
+++ b/pages/product-how-to-get-started-with-vendia.md
@@ -16,8 +16,9 @@ components:
     theme: white
     intro:
       title: Get Started with Vendia in three easy steps
-      text: "You only need three elements to be in place to launch a multi-party data
-        alliance: A data model, data, and partners. "
+      text: >-
+        ### You only need three elements to be in place to launch a multi-party data
+        alliance: A data model, data, and partners. 
     columns:
       - text: >-
           > ### Step 1
@@ -47,8 +48,9 @@ components:
     theme: light
     intro:
       title: Everything else is handled by our Saas platform
-      text: "Vendia handles all the synchronization and sharing and adapts to any
-        changes in your data model, data, or partners. "
+      text: >-
+        ### Vendia handles all the synchronization and sharing and adapts to any
+        changes in your data model, data, or partners.
     image:
       image: ""
   - type: Text

--- a/pages/product.md
+++ b/pages/product.md
@@ -30,7 +30,8 @@ components:
     theme: white
     intro:
       title: The trusted data cloud
-      text: Vendia Share was envisioned by the inventor of Serverless and is built for
+      text: >-
+        ### Vendia Share was envisioned by the inventor of Serverless and is built for
         trust, performance, compliance, and security by the best software
         engineers in the world.
     columns:

--- a/pages/use-case-compliance.md
+++ b/pages/use-case-compliance.md
@@ -59,7 +59,8 @@ components:
         wrapTheColumnInACard: false
     intro:
       title: "Compliant first. Compliant always. "
-      text: We built Vendia Share to be out-of-the-box compliant from Day 1.
+      text: >-
+        ### We built Vendia Share to be out-of-the-box compliant from Day 1.
   - type: MediaWithText
     mediaPosition: left
     text: >-

--- a/resources/podcast-episodes.md
+++ b/resources/podcast-episodes.md
@@ -9,7 +9,8 @@ components:
     resourcesType: podcasts
     intro:
       title: Circles of Trust
-      text: Real talk on real-time data sharing
+      text: >-
+        ### Real talk on real-time data sharing
     resources:
       - text: >-
           **Episode 1** | Meme Styles, Founder and President, MEASURE 


### PR DESCRIPTION
In https://github.com/vendia/site/pull/295, we switched the pancake intro text field from a `string` to a `wysiwyg`.

This updates all the instance where it was used to support the wysiwyg and keep the same styles